### PR TITLE
Docs: scrub LiteLLM from architecture-diagrams + demo-day runthrough (#83)

### DIFF
--- a/assets/architecture-diagrams.md
+++ b/assets/architecture-diagrams.md
@@ -158,7 +158,7 @@ If any step fails the fallback widget renders instead — demo is always safe.
 
 ```mermaid
 flowchart LR
-  LLM["LLM\n(Azure OpenAI\nvia LiteLLM)"]
+  LLM["LLM\n(Azure OpenAI gpt-5.5\nvia Pydantic AI)"]
 
   subgraph CONTRACT["widget_spec contract"]
     direction TB

--- a/assets/demo-day/runthrough.md
+++ b/assets/demo-day/runthrough.md
@@ -153,11 +153,11 @@ Figma / slide tool) before recording — it is the opening 8s.
 ### Beat A (0:00–0:08) — "Stack and two agents."
 
 **VISUAL:** Architecture slide image full-frame. Highlight: RN + Expo phone
-on the left, FastAPI + SQLite back, Azure OpenAI behind LiteLLM, two agent
-boxes labelled **Opportunity Agent** and **Surfacing Agent**.
+on the left, FastAPI + SQLite back, Azure OpenAI (`gpt-5.5`) via Pydantic AI,
+two agent boxes labelled **Opportunity Agent** and **Surfacing Agent**.
 **Say:** "React Native and Expo on the phone, FastAPI backend, Azure OpenAI
-through LiteLLM. Two agents — Opportunity drafts, Surfacing decides."
-**Do:** Mouse hovers over each agent box in turn, then over the LiteLLM
+gpt-5.5 through Pydantic AI. Two agents — Opportunity drafts, Surfacing decides."
+**Do:** Mouse hovers over each agent box in turn, then over the Pydantic AI
 arrow.
 
 ### Beat B (0:08–0:24) — "Three triggers → JSON layout spec."


### PR DESCRIPTION
## Summary
- Scrub the last two judge-visible LiteLLM references and align with the as-built backend (Pydantic AI + Azure OpenAI `gpt-5.5`). PR #82 already covered `work/SPEC.md`, `apps/backend/README.md`, and `CLAUDE.md`; this finishes the pair flagged in issue #83.
- `assets/architecture-diagrams.md`: GenUI pipeline LLM node now reads "Azure OpenAI gpt-5.5 via Pydantic AI".
- `assets/demo-day/runthrough.md`: Beat A visual + spoken script + hover cue now name Pydantic AI (gpt-5.5) instead of LiteLLM.

Closes #83.

## Test plan
- [x] `grep -i litellm assets/architecture-diagrams.md assets/demo-day/runthrough.md` returns nothing (verified locally; exit 1).
- [x] Out-of-scope files untouched (the 4 historical `context/` docs and `work/SUBMISSION_CHECKLIST.md`, per the issue body).
- [ ] Reviewer eyeballs the Mermaid node label + Beat A copy for tone parity with PR #82.