### PR TITLE
Backend: tighten LLM widget_spec prompt to pass validator (#66)

### DIFF
--- a/apps/backend/src/momentmarkt_backend/llm_agents.py
+++ b/apps/backend/src/momentmarkt_backend/llm_agents.py
@@ -44,7 +44,19 @@ async def run_opportunity_agent(context: dict[str, Any]) -> dict[str, Any]:
         "and one React Native GenUI widget spec. Return only the structured "
         "output. The widget tree may only use View, ScrollView, Text, Image, "
         "and Pressable. Pressable must use action='redeem'. Do not use high "
-        "intent signals; Surfacing owns per-user behavior."
+        "intent signals; Surfacing owns per-user behavior.\n"
+        "\n"
+        "WIDGET SCHEMA (strict — every node must conform or the spec is rejected):\n"
+        "- Root: { type: 'View'|'ScrollView', className?: string, children: WidgetNode[] }\n"
+        "- View / ScrollView: { type, className?: string, children: WidgetNode[] }\n"
+        "- Text: { type: 'Text', className?: string, text: string }\n"
+        "- Image: { type: 'Image', className?: string, source: string, accessibilityLabel: string }\n"
+        "- Pressable: { type: 'Pressable', className?: string, action: 'redeem', text: string }\n"
+        "- children: ALWAYS a list of valid nodes, never null, never undefined, never an object.\n"
+        "- Image.accessibilityLabel is REQUIRED on every Image node (short human description).\n"
+        "- Pressable.action MUST be the literal lowercase string 'redeem' (case-sensitive). "
+        "Never 'Redeem', 'submit', 'buy', or any other value.\n"
+        "- No extra fields beyond those listed. Max nesting depth: 12 levels."
     )
     prompt = {
         "task": "Draft one Opportunity Agent output for a merchant inbox.",


### PR DESCRIPTION
## Summary
- Closes #66. Implements the prompt-only fix identified by the #76 audit.
- Adds an explicit WIDGET SCHEMA block to `run_opportunity_agent`'s instructions so Azure GPT-5.5 emits a `widget_spec` tree that passes `genui.validate_widget_node` on the first try, eliminating the `generated_widget_invalid_used_fallback_widget` flag observed on the deployed Space.
- No validator or renderer changes; no other modules touched. The pre-existing primitive constraint line is preserved.

## What changed
Single edit in `apps/backend/src/momentmarkt_backend/llm_agents.py` — appended a strict schema block to the existing `instructions` string:

- Root must be `View`/`ScrollView` with a non-null `children` list.
- `Image.accessibilityLabel` is now explicitly required (was the #1 audit failure).
- `children` is always a list, never null/object/missing (#2 audit failure).
- `Pressable.action` MUST be the lowercase literal `'redeem'`, with explicit examples of disallowed values like `'Redeem'`, `'submit'`, `'buy'` (#3 audit failure).
- No extra fields, max depth 12 — mirrors `genui.py` exactly.

## Verification
- `uv run --project apps/backend --extra dev --extra llm pytest -k "widget or genui or opportunity"` → **61 passed, 76 deselected**.
- Live verify against the Space was skipped (no Azure creds in this worktree's local `.env`; only `OPENAI_API_KEY` is set). Acceptance criterion from #66 — three consecutive `/opportunity/generate` calls returning `widget_valid: true` and no `generated_widget_invalid_used_fallback_widget` log entry — should be checked once this lands and the Space redeploys.

## Test plan
- [ ] Merge, let Space redeploy.
- [ ] `curl -X POST <space>/opportunity/generate -d '{"city":"berlin","use_llm":true}'` × 3.
- [ ] Confirm `widget_valid: true` and `generation_log` has `pydantic_ai_generation_succeeded` without the fallback line.

## References
- Audit: #76 — full table of validator rules vs prompt deltas.
- Issue: #66 — acceptance criteria.