### PR TITLE
Backend: apply high_intent boost / lower threshold in surfacing (#72)

### DIFF
--- a/apps/backend/src/momentmarkt_backend/surfacing_agent.py
+++ b/apps/backend/src/momentmarkt_backend/surfacing_agent.py
@@ -208,9 +208,28 @@ def _trigger_strength(trigger_reason: dict[str, Any], weather_state: str) -> flo
 
 
 def _intent_boost(high_intent: dict[str, Any]) -> float:
-    screen_time = min(float(high_intent.get("active_screen_time_recent_s", 0)) / 120, 1)
-    map_foreground = 1.0 if high_intent.get("map_app_foreground_recent") else 0.0
-    coupon_browse = 1.0 if high_intent.get("coupon_browse_recent") else 0.0
+    # Accept canonical AGENT_IO.md keys plus the looser aliases the spec / mobile
+    # toggle / partner repros tend to use. Without this, callers that send
+    # `active_screen_time_min` / `map_app_foreground` / `in_app_coupon_browsing`
+    # get boost=0.0 silently and the high-intent toggle has no effect on the
+    # threshold or score (see issue #72).
+    screen_time_s = float(
+        high_intent.get(
+            "active_screen_time_recent_s",
+            high_intent.get("active_screen_time_min", 0) * 60
+            if "active_screen_time_min" in high_intent
+            else 0,
+        )
+    )
+    screen_time = min(screen_time_s / 120, 1)
+    map_foreground = 1.0 if (
+        high_intent.get("map_app_foreground_recent")
+        or high_intent.get("map_app_foreground")
+    ) else 0.0
+    coupon_browse = 1.0 if (
+        high_intent.get("coupon_browse_recent")
+        or high_intent.get("in_app_coupon_browsing")
+    ) else 0.0
     return round((screen_time + map_foreground + coupon_browse) / 3, 3)
 
 

--- a/apps/backend/tests/test_surfacing.py
+++ b/apps/backend/tests/test_surfacing.py
@@ -1,0 +1,81 @@
+"""Surfacing agent unit tests.
+
+Regression coverage for issue #72: high_intent signals must lower the
+threshold and apply a boost regardless of which schema variant the caller
+uses (canonical AGENT_IO.md keys vs the looser names in the spec/mobile
+toggle / partner repros).
+"""
+
+from fastapi.testclient import TestClient
+
+from momentmarkt_backend.main import app, store
+from momentmarkt_backend.surfacing_agent import _intent_boost
+
+
+client = TestClient(app)
+
+
+def test_intent_boost_canonical_keys() -> None:
+    boost = _intent_boost(
+        {
+            "active_screen_time_recent_s": 120,
+            "map_app_foreground_recent": True,
+            "coupon_browse_recent": True,
+        }
+    )
+    assert boost == 1.0
+
+
+def test_intent_boost_alias_keys_match_canonical() -> None:
+    """Aliases used in the issue #72 repro must produce the same boost."""
+
+    canonical = _intent_boost(
+        {
+            "active_screen_time_recent_s": 900,
+            "map_app_foreground_recent": True,
+            "coupon_browse_recent": True,
+        }
+    )
+    alias = _intent_boost(
+        {
+            "active_screen_time_min": 15,
+            "map_app_foreground": True,
+            "in_app_coupon_browsing": True,
+        }
+    )
+    assert canonical == alias == 1.0
+
+
+def test_intent_boost_empty_dict_is_zero() -> None:
+    assert _intent_boost({}) == 0.0
+
+
+def test_surfacing_high_intent_changes_score_threshold_and_boost() -> None:
+    """End-to-end: the live repro from issue #72 must now produce a different
+    boost / score / threshold than the no-high-intent baseline."""
+
+    store.reset()
+
+    baseline = client.post("/surfacing/evaluate", json={"city": "berlin"})
+    assert baseline.status_code == 200
+    base_payload = baseline.json()
+
+    high = client.post(
+        "/surfacing/evaluate",
+        json={
+            "city": "berlin",
+            "seed_offer": False,
+            "high_intent": {
+                "active_screen_time_min": 15,
+                "map_app_foreground": True,
+                "in_app_coupon_browsing": True,
+            },
+        },
+    )
+    assert high.status_code == 200
+    high_payload = high.json()
+
+    assert high_payload["boost"] > base_payload["boost"]
+    assert high_payload["score"] > base_payload["score"]
+    assert high_payload["threshold"] < base_payload["threshold"]
+    assert high_payload["intent_state"] == "active"


### PR DESCRIPTION
## Summary
- Fixes #72: `high_intent` signals didn't lower the surfacing threshold or apply a boost on the live HF Space.
- Root cause: `_intent_boost` only read the canonical AGENT_IO.md keys (`active_screen_time_recent_s` / `map_app_foreground_recent` / `coupon_browse_recent`). The issue's repro (and the spec / partner-shaped payloads) used the looser names `active_screen_time_min` / `map_app_foreground` / `in_app_coupon_browsing`, so all three lookups returned defaults and `_intent_boost` returned exactly `0.0` — matching the live observation.
- Fix: read both schemas, with `active_screen_time_min` converted to seconds. No response-shape change. The cache-hit short-circuit is unchanged because the cache key is `(offer_id, weather_state, intent_state)` — once `intent_state` flips to `"active"` it gets its own cache slot.

## Why this approach
- Smallest possible diff in `surfacing_agent._intent_boost`. No tuning of thresholds / weights — just makes the boost have an effect.
- Doesn't touch genui / opportunity_agent / llm_agents / signals.
- Existing canonical-schema tests in `test_api.py` (mia spine E2E + headline cache) keep passing — they used the canonical names already.

## Tests
New `apps/backend/tests/test_surfacing.py`:
- `test_intent_boost_canonical_keys` — pins canonical schema = 1.0 boost.
- `test_intent_boost_alias_keys_match_canonical` — pins that issue-body alias keys yield identical boost.
- `test_intent_boost_empty_dict_is_zero` — defensive default.
- `test_surfacing_high_intent_changes_score_threshold_and_boost` — end-to-end via `TestClient` using the exact issue-body payload (`active_screen_time_min: 15`, `map_app_foreground: True`, `in_app_coupon_browsing: True`); asserts boost / score / threshold all differ from the no-high-intent baseline and `intent_state == "active"`.

Full suite: `uv run --project apps/backend --extra dev --extra llm pytest` — 141 passed.

## Test plan
- [x] Unit: `_intent_boost` returns 1.0 for both schemas.
- [x] E2E (TestClient): live repro payload now flips `intent_state` to `"active"`, drops threshold to 0.58, raises score, and boost > 0.
- [x] All 141 backend tests pass.
- [ ] Manual smoke against HF Space after merge: rerun the two `curl` commands from the issue body and confirm divergence.