### PR TITLE
Mobile: SF Symbols (expo-symbols) for native iOS icon system (#97)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,6 +14,7 @@
     "expo": "~55.0.17",
     "expo-dev-client": "~55.0.28",
     "expo-status-bar": "~55.0.5",
+    "expo-symbols": "~55.0.7",
     "react": "19.2.0",
     "react-native": "0.83.6",
     "react-native-gesture-handler": "^2.30.1",

--- a/apps/mobile/src/components/DevPanel.tsx
+++ b/apps/mobile/src/components/DevPanel.tsx
@@ -1,3 +1,4 @@
+import { SymbolView } from "expo-symbols";
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Pressable, Switch, Text, View } from "react-native";
 
@@ -193,7 +194,13 @@ export function DevPanel(props: Props): ReactElement | null {
             style={s("bg-gh-chip rounded-md px-3 py-2 mb-4 border border-gh")}
           >
             <View style={s("flex-row items-center gap-2")}>
-              <Text style={s("text-[10px]")}>{"\u{1F512}"}</Text>
+              <SymbolView
+                name="lock.fill"
+                tintColor="#7d8590"
+                size={11}
+                weight="medium"
+                style={{ width: 12, height: 12 }}
+              />
               <Text style={s("mono text-[10px] text-white")} numberOfLines={1}>
                 {"{intent_token, h3_cell_r8}"}
               </Text>
@@ -549,8 +556,8 @@ function ApiHealthPill({
     .replace(/^https?:\/\//, "")
     .replace(/\.hf\.space$/, "");
 
-  const dot =
-    apiHealthy === null ? "⚪" : apiHealthy ? "\u{1F7E2}" : "\u{1F534}";
+  const dotTint =
+    apiHealthy === null ? "#7d8590" : apiHealthy ? "#3fb950" : "#f85149";
   const label =
     apiHealthy === null
       ? "checking…"
@@ -574,7 +581,13 @@ function ApiHealthPill({
         { gap: 8 },
       ]}
     >
-      <Text style={s("text-[11px]")}>{dot}</Text>
+      <SymbolView
+        name="circle.fill"
+        tintColor={dotTint}
+        size={10}
+        weight="medium"
+        style={{ width: 11, height: 11 }}
+      />
       <View style={s("flex-1")}>
         <Text style={[...s("mono text-[10px] font-semibold"), ...toneStyle]} numberOfLines={1}>
           {label}
@@ -636,7 +649,7 @@ function GenerationProvenancePill({ meta }: { meta: OpportunityMeta | null }) {
     : widgetDegraded
       ? "LLM (fallback widget)"
       : "fixture";
-  const dot = widgetClean ? "\u{1F7E2}" : widgetDegraded ? "\u{1F7E1}" : "⚪";
+  const dotTint = widgetClean ? "#3fb950" : widgetDegraded ? "#f0883e" : "#7d8590";
 
   const toneStyle =
     tone === "good"
@@ -653,7 +666,13 @@ function GenerationProvenancePill({ meta }: { meta: OpportunityMeta | null }) {
       style={s("bg-gh-chip rounded-md px-3 py-2 mb-3 border border-gh")}
     >
       <View style={[...s("flex-row items-center"), { gap: 8 }]}>
-        <Text style={s("text-[11px]")}>{dot}</Text>
+        <SymbolView
+          name="circle.fill"
+          tintColor={dotTint}
+          size={10}
+          weight="medium"
+          style={{ width: 11, height: 11 }}
+        />
         <View style={s("flex-1")}>
           <Text style={s("mono text-[10px] uppercase tracking-[0.5px] text-gh-low")}>
             generation
@@ -665,9 +684,13 @@ function GenerationProvenancePill({ meta }: { meta: OpportunityMeta | null }) {
             {label}
           </Text>
         </View>
-        <Text style={s("mono text-[10px] text-gh-low")}>
-          {expanded ? "−" : "+"}
-        </Text>
+        <SymbolView
+          name={expanded ? "chevron.up" : "chevron.down"}
+          tintColor="#7d8590"
+          size={10}
+          weight="medium"
+          style={{ width: 11, height: 11 }}
+        />
       </View>
       {expanded ? (
         <View style={s("mt-2 gap-1")}>

--- a/apps/mobile/src/components/MapTopChip.tsx
+++ b/apps/mobile/src/components/MapTopChip.tsx
@@ -1,3 +1,4 @@
+import { SymbolView } from "expo-symbols";
 import { type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -81,14 +82,28 @@ export function MapTopChip({
           },
         ]}
       >
+        <SymbolView
+          name="mappin.and.ellipse"
+          tintColor="#17120f"
+          size={13}
+          weight="medium"
+          style={{ width: 16, height: 16, marginRight: 4 }}
+        />
         <Text style={[...s("text-[13px] text-ink"), { fontWeight: "500" }]} numberOfLines={1}>
-          {"📍 "}
           <Text style={[...s("text-[13px] text-ink"), { fontWeight: "700" }]}>
             {city}
           </Text>
           {area ? ` ${area}` : ""}
           {"  ·  "}
-          {"☔ "}
+        </Text>
+        <SymbolView
+          name="cloud.rain.fill"
+          tintColor="#17120f"
+          size={13}
+          weight="medium"
+          style={{ width: 16, height: 16, marginRight: 4 }}
+        />
+        <Text style={[...s("text-[13px] text-ink"), { fontWeight: "500" }]} numberOfLines={1}>
           {Math.round(tempC)}
           {"° "}
           {weatherSummary}

--- a/apps/mobile/src/screens/HistoryScreen.tsx
+++ b/apps/mobile/src/screens/HistoryScreen.tsx
@@ -1,3 +1,4 @@
+import { SymbolView } from "expo-symbols";
 import { useMemo, useState } from "react";
 import {
   Image,
@@ -169,7 +170,13 @@ export function HistoryScreen({
   if (redemptions.length === 0) {
     return (
       <View style={s("flex-1 bg-cream items-center justify-center px-5")}>
-        <Text style={[{ fontSize: 60 }]}>🪙</Text>
+        <SymbolView
+          name="wallet.pass.fill"
+          tintColor="#6f3f2c"
+          size={60}
+          weight="medium"
+          style={{ width: 64, height: 64 }}
+        />
         <Text style={[...s("mt-4 text-ink"), { fontSize: 18, fontWeight: "800" }]}>
           No cashbacks yet. Get out there!
         </Text>

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,3 +1,4 @@
+import { SymbolView } from "expo-symbols";
 import {
   type ComponentProps,
   type ReactElement,
@@ -152,9 +153,13 @@ export function SettingsScreen(props: Props): ReactElement | null {
             },
           ]}
         >
-          <Text style={[...s("text-base font-black text-ink"), { lineHeight: 18 }]}>
-            ✕
-          </Text>
+          <SymbolView
+            name="xmark"
+            tintColor="#17120f"
+            size={14}
+            weight="medium"
+            style={{ width: 14, height: 14 }}
+          />
         </Pressable>
       </View>
 
@@ -308,7 +313,13 @@ export function SettingsScreen(props: Props): ReactElement | null {
             <Text style={s("text-base font-bold text-ink")}>
               Reset demo
             </Text>
-            <Text style={[...s("text-base text-spark"), { lineHeight: 18 }]}>↺</Text>
+            <SymbolView
+              name="arrow.counterclockwise"
+              tintColor="#f2542d"
+              size={16}
+              weight="medium"
+              style={{ width: 18, height: 18 }}
+            />
           </Pressable>
         </View>
         <SectionFooter>
@@ -414,9 +425,13 @@ function ActionRow({ label, onPress }: { label: string; onPress?: () => void }) 
       ]}
     >
       <Text style={s("text-base text-ink")}>{label}</Text>
-      <Text style={[...s("text-base"), { color: "rgba(23, 18, 15, 0.3)", lineHeight: 18 }]}>
-        ›
-      </Text>
+      <SymbolView
+        name="chevron.right"
+        tintColor="rgba(23, 18, 15, 0.3)"
+        size={14}
+        weight="medium"
+        style={{ width: 14, height: 14 }}
+      />
     </Pressable>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       expo-status-bar:
         specifier: ~55.0.5
         version: 55.0.5(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-symbols:
+        specifier: ~55.0.7
+        version: 55.0.7(expo-font@55.0.6(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -622,6 +625,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@expo-google-fonts/material-symbols@0.4.33':
+    resolution: {integrity: sha512-GQFy5tx7LBiRJttLYhz+KPmoVCQSVXiJPXVgMt/d8BWYbnJmw0nFixZtOaZQJE9F/L6vni3totwPNmbrdMi3ow==}
 
   '@expo/cli@55.0.26':
     resolution: {integrity: sha512-Ud9gpeGMF5RIL42LXvCw3k3mWK8rf/P2wu+Yrzz9Do1kcFKZeT9Vy2D/xukjdr/Xw+ELba87ThOot17GsPiWjw==}
@@ -1668,6 +1674,14 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-symbols@55.0.7:
+    resolution: {integrity: sha512-y4ALLbncSGQzhFLw1PaIBbO39xzaw3ie249HmK6zK/WLJYfw4Z/9UU4iPKO3KCE4FyCKIzd+yRsvzvlri23YrQ==}
+    peerDependencies:
+      expo: '*'
+      expo-font: '*'
+      react: '*'
+      react-native: '*'
+
   expo-updates-interface@55.1.6:
     resolution: {integrity: sha512-evxNpagCkjT3lE6bGV570TFzRtKuIuLY8I37RYHoriXCJ+ZKCN1hbmklK29uAixya+BxGpeTI2K4FqYeJLvfrw==}
     peerDependencies:
@@ -2639,6 +2653,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sf-symbols-typescript@2.2.0:
+    resolution: {integrity: sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==}
+    engines: {node: '>=10'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3670,6 +3688,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@expo-google-fonts/material-symbols@0.4.33': {}
 
   '@expo/cli@55.0.26(@expo/dom-webview@55.0.5)(expo-constants@55.0.15(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)))(expo-font@55.0.6(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.17)(react-dom@19.1.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
@@ -5036,6 +5056,15 @@ snapshots:
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
+  expo-symbols@55.0.7(expo-font@55.0.6(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@expo-google-fonts/material-symbols': 0.4.33
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(react-dom@19.1.0(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-font: 55.0.6(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
+      sf-symbols-typescript: 2.2.0
+
   expo-updates-interface@55.1.6(expo@55.0.17):
     dependencies:
       expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(react-dom@19.1.0(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -6295,6 +6324,8 @@ snapshots:
   set-blocking@2.0.0: {}
 
   setprototypeof@1.2.0: {}
+
+  sf-symbols-typescript@2.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Closes part of #97 — pivot from `@expo/vector-icons` to **SF Symbols via `expo-symbols`** for native iOS authenticity (the demo runs on the iOS Simulator, so SF Symbols read as "real Apple app" in a way no other library does).

Swaps emoji / unicode glyphs across **DevPanel · MapTopChip · HistoryScreen · SettingsScreen** to `<SymbolView>`. All swaps use `weight="medium"` for a single consistent stroke, and `size` + `tintColor` map 1:1 onto the previous text size + color so layout is unchanged.

## Coordination

Stayed strictly out of mmtf's lane:
- **App.tsx** (BottomMenu, DevPanelTrigger, DevPanelOverlay) — untouched
- **WalletSheetContent.tsx** (BottomSheet skeleton) — untouched
- **CityMap.tsx** — left as-is (deliberate emoji glyphs from #71 per issue body)
- **LockScreen.tsx** — left as-is (no longer rendered; out of scope)
- **SurfaceNotification.tsx** — left as-is (dead component, not imported anywhere; deferred)

## Files touched

| File | Swaps |
|------|-------|
| `apps/mobile/package.json` | added `expo-symbols ~55.0.7` |
| `pnpm-lock.yaml` | regenerated by `npx expo install` |
| `apps/mobile/src/components/MapTopChip.tsx` | `📍`, `☔` → `mappin.and.ellipse`, `cloud.rain.fill` |
| `apps/mobile/src/components/DevPanel.tsx` | `🔒` lock; `⚪/🟢/🔴` API-health dot; `⚪/🟢/🟡` LLM-provenance dot; `+/−` expander |
| `apps/mobile/src/screens/SettingsScreen.tsx` | `✕` close, `↺` reset, `›` action chevron |
| `apps/mobile/src/screens/HistoryScreen.tsx` | `🪙` empty-state coin |

Total: 4 implementation files + 2 lockfiles touched, **9 distinct icon-swap sites**.

## Icon mapping table

| Emoji / glyph | SF Symbol name | Used in |
|---|---|---|
| `📍` | `mappin.and.ellipse` | MapTopChip |
| `☔` | `cloud.rain.fill` | MapTopChip |
| `🔒` | `lock.fill` | DevPanel privacy_envelope |
| `⚪/🟢/🔴` (status) | `circle.fill` (tint per state) | DevPanel API health pill |
| `⚪/🟢/🟡` (provenance) | `circle.fill` (tint per state) | DevPanel generation pill |
| `+` / `−` (expander) | `chevron.down` / `chevron.up` | DevPanel generation pill |
| `✕` | `xmark` | SettingsScreen header close |
| `↺` | `arrow.counterclockwise` | SettingsScreen reset-demo row |
| `›` | `chevron.right` | SettingsScreen ActionRow |
| `🪙` | `wallet.pass.fill` | HistoryScreen empty state |

For status dots, the SF Symbol stays the same (`circle.fill`) and the *tint* changes per state — same semantic mapping as the original emoji (green = good, red = down, yellow = degraded, grey = unknown), but rendered as a real iOS symbol.

## Deferred / not swapped

- `Run Surfacing Agent →` arrow inside the DevPanel CTA button label — kept as inline text (it's a typographic affordance inside a button label, not an icon). Swapping would require restructuring the button into a flex row, which violates the "don't change layout" constraint.
- Currency `€` left everywhere (not an icon).
- Brand `M` avatar block left untouched (brand mark, not an icon).
- `SurfaceNotification.tsx` `☔` default emoji prop — file is dead code (no longer imported by App.tsx per the comment on line 54). Defer cleanup.
- `LockScreen.tsx` cloud `☁` and dot `◉` — file is no longer rendered.
- `WalletSheetContent.tsx` gear `⚙`, cloud `☁`, dot `◉` — mmtf's BottomSheet lane.
- `CityMap.tsx` category-marker emoji (`☕ 🥨 📚 🏃 📰 🛒 📍`) — explicitly excluded by the issue body (deliberate map-marker glyphs from #71).

## Test plan

- [ ] `pnpm mobile:typecheck` passes (verified locally — clean)
- [ ] Visual check on iOS Simulator: MapTopChip shows pin + cloud-rain symbols flanking the city name
- [ ] Visual check: DevPanel API-health dot renders as a tinted SF circle (green when API up)
- [ ] Visual check: SettingsScreen close `✕` and reset `↺` render as crisp SF Symbols
- [ ] Visual check: HistoryScreen empty state shows wallet icon (force-clear redemptions list to test)