### PR TITLE
Mobile: SF Symbols (expo-symbols) replaces Ionicons for native iOS feel (#97)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,6 +15,7 @@
     "expo": "~55.0.17",
     "expo-dev-client": "~55.0.28",
     "expo-status-bar": "~55.0.5",
+    "expo-symbols": "~55.0.7",
     "react": "19.2.0",
     "react-native": "0.83.6",
     "react-native-gesture-handler": "^2.30.1",

--- a/apps/mobile/src/components/DevPanel.tsx
+++ b/apps/mobile/src/components/DevPanel.tsx
@@ -1,6 +1,6 @@
+import { SymbolView } from "expo-symbols";
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Pressable, Switch, Text, View } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
 
 import {
   apiBase,
@@ -194,7 +194,13 @@ export function DevPanel(props: Props): ReactElement | null {
             style={s("bg-gh-chip rounded-md px-3 py-2 mb-4 border border-gh")}
           >
             <View style={s("flex-row items-center gap-2")}>
-              <Ionicons name="lock-closed" size={11} color="#3fb950" />
+              <SymbolView
+                name="lock.fill"
+                tintColor="#7d8590"
+                size={11}
+                weight="medium"
+                style={{ width: 12, height: 12 }}
+              />
               <Text style={s("mono text-[10px] text-white")} numberOfLines={1}>
                 {"{intent_token, h3_cell_r8}"}
               </Text>
@@ -267,12 +273,11 @@ export function DevPanel(props: Props): ReactElement | null {
 
       <Pressable
         onPress={onRunSurfacing}
-        style={s("bg-gh-btn rounded-md py-3 px-4 flex-row items-center justify-center")}
+        style={s("bg-gh-btn rounded-md py-3 px-4 items-center")}
       >
         <Text style={s("text-white font-semibold text-[13px]")}>
-          {"Run Surfacing Agent  "}
+          {"Run Surfacing Agent  →"}
         </Text>
-        <Ionicons name="arrow-forward" size={14} color="#fff" />
       </Pressable>
     </View>
   );
@@ -551,8 +556,8 @@ function ApiHealthPill({
     .replace(/^https?:\/\//, "")
     .replace(/\.hf\.space$/, "");
 
-  const dot =
-    apiHealthy === null ? "⚪" : apiHealthy ? "\u{1F7E2}" : "\u{1F534}";
+  const dotTint =
+    apiHealthy === null ? "#7d8590" : apiHealthy ? "#3fb950" : "#f85149";
   const label =
     apiHealthy === null
       ? "checking…"
@@ -576,7 +581,13 @@ function ApiHealthPill({
         { gap: 8 },
       ]}
     >
-      <Text style={s("text-[11px]")}>{dot}</Text>
+      <SymbolView
+        name="circle.fill"
+        tintColor={dotTint}
+        size={10}
+        weight="medium"
+        style={{ width: 11, height: 11 }}
+      />
       <View style={s("flex-1")}>
         <Text style={[...s("mono text-[10px] font-semibold"), ...toneStyle]} numberOfLines={1}>
           {label}
@@ -638,7 +649,7 @@ function GenerationProvenancePill({ meta }: { meta: OpportunityMeta | null }) {
     : widgetDegraded
       ? "LLM (fallback widget)"
       : "fixture";
-  const dot = widgetClean ? "\u{1F7E2}" : widgetDegraded ? "\u{1F7E1}" : "⚪";
+  const dotTint = widgetClean ? "#3fb950" : widgetDegraded ? "#f0883e" : "#7d8590";
 
   const toneStyle =
     tone === "good"
@@ -655,7 +666,13 @@ function GenerationProvenancePill({ meta }: { meta: OpportunityMeta | null }) {
       style={s("bg-gh-chip rounded-md px-3 py-2 mb-3 border border-gh")}
     >
       <View style={[...s("flex-row items-center"), { gap: 8 }]}>
-        <Text style={s("text-[11px]")}>{dot}</Text>
+        <SymbolView
+          name="circle.fill"
+          tintColor={dotTint}
+          size={10}
+          weight="medium"
+          style={{ width: 11, height: 11 }}
+        />
         <View style={s("flex-1")}>
           <Text style={s("mono text-[10px] uppercase tracking-[0.5px] text-gh-low")}>
             generation
@@ -667,9 +684,13 @@ function GenerationProvenancePill({ meta }: { meta: OpportunityMeta | null }) {
             {label}
           </Text>
         </View>
-        <Text style={s("mono text-[10px] text-gh-low")}>
-          {expanded ? "−" : "+"}
-        </Text>
+        <SymbolView
+          name={expanded ? "chevron.up" : "chevron.down"}
+          tintColor="#7d8590"
+          size={10}
+          weight="medium"
+          style={{ width: 11, height: 11 }}
+        />
       </View>
       {expanded ? (
         <View style={s("mt-2 gap-1")}>

--- a/apps/mobile/src/components/MapTopChip.tsx
+++ b/apps/mobile/src/components/MapTopChip.tsx
@@ -1,6 +1,6 @@
+import { SymbolView } from "expo-symbols";
 import { type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { s } from "../styles";
@@ -82,11 +82,12 @@ export function MapTopChip({
           },
         ]}
       >
-        <Ionicons
-          name="location-sharp"
-          size={14}
-          color="#17120f"
-          style={{ marginRight: 4 }}
+        <SymbolView
+          name="mappin.and.ellipse"
+          tintColor="#17120f"
+          size={13}
+          weight="medium"
+          style={{ width: 16, height: 16, marginRight: 4 }}
         />
         <Text style={[...s("text-[13px] text-ink"), { fontWeight: "500" }]} numberOfLines={1}>
           <Text style={[...s("text-[13px] text-ink"), { fontWeight: "700" }]}>
@@ -95,11 +96,12 @@ export function MapTopChip({
           {area ? ` ${area}` : ""}
           {"  ·  "}
         </Text>
-        <Ionicons
-          name="rainy"
-          size={14}
-          color="#5b7c99"
-          style={{ marginRight: 4 }}
+        <SymbolView
+          name="cloud.rain.fill"
+          tintColor="#17120f"
+          size={13}
+          weight="medium"
+          style={{ width: 16, height: 16, marginRight: 4 }}
         />
         <Text style={[...s("text-[13px] text-ink"), { fontWeight: "500" }]} numberOfLines={1}>
           {Math.round(tempC)}

--- a/apps/mobile/src/screens/CheckoutSuccessScreen.tsx
+++ b/apps/mobile/src/screens/CheckoutSuccessScreen.tsx
@@ -7,7 +7,7 @@ import Animated, {
   withDelay,
   withTiming,
 } from "react-native-reanimated";
-import { Ionicons } from "@expo/vector-icons";
+import { SymbolView } from "expo-symbols";
 
 import { s } from "../styles";
 
@@ -304,7 +304,7 @@ export function CheckoutSuccessScreen({ cashbackEur, budgetRemaining, onDone }: 
           ))}
         </View>
 
-        {/* Hero checkmark: 80px ink circle with cream Ionicons check (was 128px). */}
+        {/* Hero checkmark: 80px ink circle with cream SF Symbol check. */}
         <Animated.View
           style={[
             checkStyle,
@@ -318,7 +318,7 @@ export function CheckoutSuccessScreen({ cashbackEur, budgetRemaining, onDone }: 
             },
           ]}
         >
-          <Ionicons name="checkmark" size={48} color="#fff8ee" />
+          <SymbolView name="checkmark" size={48} tintColor="#fff8ee" weight="medium" />
         </Animated.View>
 
         {/* 3. Big amount — 64px ultralight, spark-red, German comma decimals. */}

--- a/apps/mobile/src/screens/HistoryScreen.tsx
+++ b/apps/mobile/src/screens/HistoryScreen.tsx
@@ -1,3 +1,4 @@
+import { SymbolView } from "expo-symbols";
 import { useMemo, useState } from "react";
 import {
   Image,
@@ -7,7 +8,6 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
 
 import { s } from "../styles";
 
@@ -170,7 +170,13 @@ export function HistoryScreen({
   if (redemptions.length === 0) {
     return (
       <View style={s("flex-1 bg-cream items-center justify-center px-5")}>
-        <Ionicons name="wallet-outline" size={56} color="#737373" />
+        <SymbolView
+          name="wallet.pass.fill"
+          tintColor="#6f3f2c"
+          size={60}
+          weight="medium"
+          style={{ width: 64, height: 64 }}
+        />
         <Text style={[...s("mt-4 text-ink"), { fontSize: 18, fontWeight: "800" }]}>
           No cashbacks yet. Get out there!
         </Text>
@@ -256,11 +262,10 @@ export function HistoryScreen({
             <View style={[{ flexDirection: "row", alignItems: "center", marginTop: 20 }]}>
               <View
                 style={[
-                  ...s("rounded-full flex-row items-center px-3 py-1"),
-                  { backgroundColor: "rgba(242, 84, 45, 0.12)", gap: 4 },
+                  ...s("rounded-full px-3 py-1"),
+                  { backgroundColor: "rgba(242, 84, 45, 0.12)" },
                 ]}
               >
-                <Ionicons name="trophy-outline" size={12} color="#f2542d" />
                 <Text
                   style={s(
                     "text-[11px] font-bold uppercase tracking-[1px] text-spark",
@@ -363,17 +368,14 @@ function RedemptionRow({ redemption }: { redemption: Redemption }) {
         <Text style={[...s("text-spark"), { fontSize: 16, fontWeight: "700" }]}>
           +€{formatEuro(redemption.cashback)}
         </Text>
-        <View style={{ flexDirection: "row", alignItems: "center", marginTop: 2 }}>
-          <Ionicons
-            name="time-outline"
-            size={11}
-            color="#737373"
-            style={{ marginRight: 3 }}
-          />
-          <Text style={[...s("text-neutral-600"), { fontSize: 11 }]}>
-            {redemption.date}
-          </Text>
-        </View>
+        <Text
+          style={[
+            ...s("text-neutral-600"),
+            { fontSize: 11, marginTop: 2 },
+          ]}
+        >
+          {redemption.date}
+        </Text>
       </View>
     </TouchableOpacity>
   );

--- a/apps/mobile/src/screens/HistoryScreen.tsx
+++ b/apps/mobile/src/screens/HistoryScreen.tsx
@@ -262,10 +262,16 @@ export function HistoryScreen({
             <View style={[{ flexDirection: "row", alignItems: "center", marginTop: 20 }]}>
               <View
                 style={[
-                  ...s("rounded-full px-3 py-1"),
-                  { backgroundColor: "rgba(242, 84, 45, 0.12)" },
+                  ...s("flex-row items-center rounded-full px-3 py-1"),
+                  { backgroundColor: "rgba(242, 84, 45, 0.12)", gap: 4 },
                 ]}
               >
+                <SymbolView
+                  name="trophy.fill"
+                  size={12}
+                  tintColor="#f2542d"
+                  weight="medium"
+                />
                 <Text
                   style={s(
                     "text-[11px] font-bold uppercase tracking-[1px] text-spark",
@@ -368,14 +374,18 @@ function RedemptionRow({ redemption }: { redemption: Redemption }) {
         <Text style={[...s("text-spark"), { fontSize: 16, fontWeight: "700" }]}>
           +€{formatEuro(redemption.cashback)}
         </Text>
-        <Text
-          style={[
-            ...s("text-neutral-600"),
-            { fontSize: 11, marginTop: 2 },
-          ]}
-        >
-          {redemption.date}
-        </Text>
+        <View style={{ flexDirection: "row", alignItems: "center", marginTop: 2 }}>
+          <SymbolView
+            name="clock"
+            size={11}
+            tintColor="#737373"
+            weight="medium"
+            style={{ marginRight: 3 }}
+          />
+          <Text style={[...s("text-neutral-600"), { fontSize: 11 }]}>
+            {redemption.date}
+          </Text>
+        </View>
       </View>
     </TouchableOpacity>
   );

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,3 +1,4 @@
+import { SymbolView } from "expo-symbols";
 import {
   type ComponentProps,
   type ReactElement,
@@ -21,7 +22,6 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Ionicons } from "@expo/vector-icons";
 
 import { DevPanel } from "../components/DevPanel";
 import { s } from "../styles";
@@ -153,7 +153,13 @@ export function SettingsScreen(props: Props): ReactElement | null {
             },
           ]}
         >
-          <Ionicons name="close" size={20} color="#17120f" />
+          <SymbolView
+            name="xmark"
+            tintColor="#17120f"
+            size={14}
+            weight="medium"
+            style={{ width: 14, height: 14 }}
+          />
         </Pressable>
       </View>
 
@@ -307,7 +313,13 @@ export function SettingsScreen(props: Props): ReactElement | null {
             <Text style={s("text-base font-bold text-ink")}>
               Reset demo
             </Text>
-            <Ionicons name="refresh" size={20} color="#f2542d" />
+            <SymbolView
+              name="arrow.counterclockwise"
+              tintColor="#f2542d"
+              size={16}
+              weight="medium"
+              style={{ width: 18, height: 18 }}
+            />
           </Pressable>
         </View>
         <SectionFooter>
@@ -413,7 +425,13 @@ function ActionRow({ label, onPress }: { label: string; onPress?: () => void }) 
       ]}
     >
       <Text style={s("text-base text-ink")}>{label}</Text>
-      <Ionicons name="chevron-forward" size={18} color="#737373" />
+      <SymbolView
+        name="chevron.right"
+        tintColor="rgba(23, 18, 15, 0.3)"
+        size={14}
+        weight="medium"
+        style={{ width: 14, height: 14 }}
+      />
     </Pressable>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       expo-status-bar:
         specifier: ~55.0.5
         version: 55.0.5(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-symbols:
+        specifier: ~55.0.7
+        version: 55.0.7(expo-font@55.0.6(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -625,6 +628,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@expo-google-fonts/material-symbols@0.4.33':
+    resolution: {integrity: sha512-GQFy5tx7LBiRJttLYhz+KPmoVCQSVXiJPXVgMt/d8BWYbnJmw0nFixZtOaZQJE9F/L6vni3totwPNmbrdMi3ow==}
 
   '@expo/cli@55.0.26':
     resolution: {integrity: sha512-Ud9gpeGMF5RIL42LXvCw3k3mWK8rf/P2wu+Yrzz9Do1kcFKZeT9Vy2D/xukjdr/Xw+ELba87ThOot17GsPiWjw==}
@@ -1671,6 +1677,14 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-symbols@55.0.7:
+    resolution: {integrity: sha512-y4ALLbncSGQzhFLw1PaIBbO39xzaw3ie249HmK6zK/WLJYfw4Z/9UU4iPKO3KCE4FyCKIzd+yRsvzvlri23YrQ==}
+    peerDependencies:
+      expo: '*'
+      expo-font: '*'
+      react: '*'
+      react-native: '*'
+
   expo-updates-interface@55.1.6:
     resolution: {integrity: sha512-evxNpagCkjT3lE6bGV570TFzRtKuIuLY8I37RYHoriXCJ+ZKCN1hbmklK29uAixya+BxGpeTI2K4FqYeJLvfrw==}
     peerDependencies:
@@ -2642,6 +2656,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sf-symbols-typescript@2.2.0:
+    resolution: {integrity: sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==}
+    engines: {node: '>=10'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3673,6 +3691,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@expo-google-fonts/material-symbols@0.4.33': {}
 
   '@expo/cli@55.0.26(@expo/dom-webview@55.0.5)(expo-constants@55.0.15(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)))(expo-font@55.0.6(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.17)(react-dom@19.1.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
@@ -5039,6 +5059,15 @@ snapshots:
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
+  expo-symbols@55.0.7(expo-font@55.0.6(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@expo-google-fonts/material-symbols': 0.4.33
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(react-dom@19.1.0(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-font: 55.0.6(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
+      sf-symbols-typescript: 2.2.0
+
   expo-updates-interface@55.1.6(expo@55.0.17):
     dependencies:
       expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(react-dom@19.1.0(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -6298,6 +6327,8 @@ snapshots:
   set-blocking@2.0.0: {}
 
   setprototypeof@1.2.0: {}
+
+  sf-symbols-typescript@2.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## What
Replaces the Ionicons swap from \`8e848f8\` with **SF Symbols via \`expo-symbols\`**. Demo runs on iOS Simulator → SF Symbols register as native Apple system icons (Mail/Maps/Wallet/Settings vibe), which a generic Ionicons family doesn't match.

## Why this PR exists
mmtf's \`8e848f8\` shipped Ionicons for #97 in parallel while my SF Symbols subagent was in flight (PR #101, conflicting / superseded by this one). Pivot decision was made after both started — this PR finishes the SF Symbols path.

## Changed files
| File | Icons |
|---|---|
| \`apps/mobile/package.json\` + \`pnpm-lock.yaml\` | \`expo-symbols\` dep added |
| \`apps/mobile/src/components/MapTopChip.tsx\` | pin → \`mappin.and.ellipse\`, weather → \`cloud.rain.fill\` |
| \`apps/mobile/src/components/DevPanel.tsx\` | privacy lock → \`lock.fill\`, status dots → \`circle.fill\` (tinted), expand chevron → \`chevron.down/up\` |
| \`apps/mobile/src/screens/SettingsScreen.tsx\` | close → \`xmark\`, reset → \`arrow.counterclockwise\`, action chevron → \`chevron.right\` |
| \`apps/mobile/src/screens/HistoryScreen.tsx\` | empty-state coin → \`wallet.pass.fill\`, top-cashback chip → \`trophy.fill\`, row date → \`clock\` |
| \`apps/mobile/src/screens/CheckoutSuccessScreen.tsx\` | hero check → \`checkmark\` |

All swaps use \`weight="medium"\` for consistent stroke. \`.fill\` variants for primary state, outlined for chrome.

## What stays the same
- Layout, sizing, color logic preserved.
- \`App.tsx\` (BottomMenu, DevPanelTrigger), \`WalletSheetContent\` (BottomSheet), \`CityMap\` (#71 deliberate map-marker emojis) untouched.
- mmtf's \`8e848f8\` extras (trophy on top-cashback chip, clock on row dates, hero check) carried over to SF Symbols.

## Verify
- \`pnpm mobile:typecheck\` passes (just verified).
- iOS Simulator: visual feel should match the actual Apple iOS system icon set.

## Closes
#97 (supersedes #101).