### PR TITLE
Merchant: live API status + polling confidence (#109)

### DIFF
--- a/apps/merchant/src/ApiStatus.tsx
+++ b/apps/merchant/src/ApiStatus.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from "react";
+
+type Status = "connecting" | "online" | "degraded" | "offline";
+
+const POLL_INTERVAL_MS = 5000;
+// If we go this long without a successful response, drop from online -> degraded.
+const DEGRADED_AFTER_MS = 12_000;
+// If we go this long without a successful response, drop to offline.
+const OFFLINE_AFTER_MS = 25_000;
+
+function relativeAgo(ms: number | null): string {
+  if (ms == null) return "no contact";
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  if (seconds < 2) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function statusLabel(status: Status): string {
+  switch (status) {
+    case "connecting":
+      return "Connecting";
+    case "online":
+      return "Live";
+    case "degraded":
+      return "Slow";
+    case "offline":
+      return "Offline";
+  }
+}
+
+export function ApiStatus() {
+  const [status, setStatus] = useState<Status>("connecting");
+  const [lastSuccess, setLastSuccess] = useState<number | null>(null);
+  const [pollTick, setPollTick] = useState(0);
+  const [, setNow] = useState(Date.now());
+  const lastSuccessRef = useRef<number | null>(null);
+
+  // Health poll loop.
+  useEffect(() => {
+    let cancelled = false;
+    const baseUrl = import.meta.env.VITE_API_URL || "http://localhost:8000";
+
+    const downgrade = () => {
+      const last = lastSuccessRef.current;
+      if (last == null) {
+        setStatus("offline");
+        return;
+      }
+      const sinceLast = Date.now() - last;
+      if (sinceLast >= OFFLINE_AFTER_MS) setStatus("offline");
+      else if (sinceLast >= DEGRADED_AFTER_MS) setStatus("degraded");
+    };
+
+    const fetchHealth = async () => {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 4000);
+        const r = await fetch(`${baseUrl}/health`, { signal: controller.signal });
+        clearTimeout(timeout);
+        if (cancelled) return;
+        if (r.ok) {
+          const ts = Date.now();
+          lastSuccessRef.current = ts;
+          setLastSuccess(ts);
+          setStatus("online");
+          setPollTick((tick) => tick + 1);
+          return;
+        }
+        // Non-2xx response — backend reachable but unhealthy.
+        downgrade();
+      } catch {
+        if (cancelled) return;
+        downgrade();
+      }
+    };
+
+    fetchHealth();
+    const id = setInterval(fetchHealth, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  // Tick clock so the "x ago" label refreshes between polls.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const ago = lastSuccess == null ? null : Date.now() - lastSuccess;
+  const label = statusLabel(status);
+
+  return (
+    <div
+      className={`api-status api-status-${status}`}
+      role="status"
+      aria-live="polite"
+      title={`Backend health · last contact ${relativeAgo(ago)}`}
+    >
+      <span className="api-status-dot" key={pollTick} />
+      <span className="api-status-label">{label}</span>
+      <span className="api-status-meta">{relativeAgo(ago)}</span>
+    </div>
+  );
+}

--- a/apps/merchant/src/main.tsx
+++ b/apps/merchant/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import density from "../../../data/transactions/berlin-density.json";
+import { ApiStatus } from "./ApiStatus";
 import "./styles.css";
 
 const MERCHANT_ID = "berlin-mitte-cafe-bondi";
@@ -177,7 +178,10 @@ function App() {
             signals for the Berlin lunch window.
           </p>
         </div>
-        <LiveStatus poll={poll} />
+        <div className="hero-status">
+          <ApiStatus />
+          <LiveStatus poll={poll} />
+        </div>
       </section>
 
       <DemandGapHero />

--- a/apps/merchant/src/styles.css
+++ b/apps/merchant/src/styles.css
@@ -673,6 +673,108 @@ code {
   background: linear-gradient(90deg, #2c7c59, #9ee6b0);
 }
 
+.hero-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  min-width: min(320px, 100%);
+}
+
+.api-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgba(247, 244, 235, 0.92);
+  font-size: 0.75rem;
+  font-weight: 800;
+  white-space: nowrap;
+  transition: background 200ms ease, border-color 200ms ease;
+}
+
+.api-status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #94f7bd;
+  box-shadow: 0 0 0 0 rgba(148, 247, 189, 0.6);
+  animation: api-status-tick 900ms ease-out;
+}
+
+.api-status-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.api-status-meta {
+  color: rgba(247, 244, 235, 0.6);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.api-status-online .api-status-dot {
+  background: #94f7bd;
+  box-shadow: 0 0 0 6px rgba(148, 247, 189, 0.18);
+}
+
+.api-status-connecting .api-status-dot {
+  background: #f6d57a;
+  box-shadow: 0 0 0 6px rgba(246, 213, 122, 0.2);
+  animation: api-status-breathe 1400ms ease-in-out infinite;
+}
+
+.api-status-degraded {
+  background: rgba(120, 80, 0, 0.42);
+  border-color: rgba(246, 213, 122, 0.35);
+}
+
+.api-status-degraded .api-status-dot {
+  background: #f6b54a;
+  box-shadow: 0 0 0 6px rgba(246, 181, 74, 0.22);
+  animation: none;
+}
+
+.api-status-offline {
+  background: rgba(120, 30, 30, 0.45);
+  border-color: rgba(255, 130, 130, 0.32);
+}
+
+.api-status-offline .api-status-dot {
+  background: #ff7676;
+  box-shadow: 0 0 0 6px rgba(255, 118, 118, 0.22);
+  animation: none;
+}
+
+@keyframes api-status-tick {
+  0% {
+    transform: scale(0.6);
+    box-shadow: 0 0 0 0 rgba(148, 247, 189, 0.7);
+  }
+  60% {
+    transform: scale(1.25);
+    box-shadow: 0 0 0 10px rgba(148, 247, 189, 0);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 6px rgba(148, 247, 189, 0.18);
+  }
+}
+
+@keyframes api-status-breathe {
+  0%, 100% {
+    box-shadow: 0 0 0 4px rgba(246, 213, 122, 0.18);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(246, 213, 122, 0.32);
+  }
+}
+
 @media (max-width: 860px) {
   .hero-panel,
   .card-topline,
@@ -700,5 +802,10 @@ code {
   .rules-panel {
     padding: 22px;
     border-radius: 24px;
+  }
+
+  .hero-status {
+    align-items: flex-start;
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary

Layers an additional `<ApiStatus />` chip onto the merchant header beside the existing `LiveStatus` pill that mmtf landed in `0b9895b`. The new chip independently polls `GET /health` every 5s and adds three things issue #109 calls for that the summary-only poll cannot show:

- **Three states with a colored dot** — green `Live`, yellow `Slow` (no `/health` contact for 12s+), red `Offline` (25s+). Connecting state breathes yellow before the first response.
- **Auto-updating relative timestamp** — `just now` / `2s ago` / `15s ago`, re-rendered every second so a frozen screenshot is obvious on camera.
- **Per-poll pulse** — the dot is keyed on the poll counter, so each successful tick replays a quick scale/glow animation. That's the "polling confidence" tell — viewers can see data is live, not stale.

`LiveStatus` is left untouched and still drives the data-feed pill (last-fetch wall clock, base URL, error detail). The two indicators stack inside a `.hero-status` flex container in the top-right of the hero panel.

`fetch` is used directly with a 4s `AbortController` timeout. Polling interval is 5s — well clear of the 1s lower bound called out in the brief. No new deps. Fully self-contained in `apps/merchant/`.

## Test plan

- [ ] `pnpm merchant:typecheck` (passes locally)
- [ ] Run `pnpm merchant:dev` with `VITE_API_URL` pointed at the HF Space — chip turns green, dot pulses on each refresh, `Ns ago` increments.
- [ ] Stop the backend mid-session — within ~12s the chip flips to yellow `Slow`, then red `Offline` after ~25s; `LiveStatus` independently flips to fixture-fallback.
- [ ] Mobile viewport ( <860px ) — `.hero-status` left-aligns and stacks under the title.

Refs #109. Recording polish (#106) lane untouched.