### PR TITLE
Merchant: recording-ready inbox polish (#106)

### DIFF
--- a/apps/merchant/src/main.tsx
+++ b/apps/merchant/src/main.tsx
@@ -19,9 +19,6 @@ function findCafeBondi() {
 
 const merchant = findCafeBondi();
 
-const latestSample = merchant.live_samples.find((sample) =>
-  sample.time_local.includes("13:30:00"),
-);
 const approvalRule = merchant.autopilot_rule_hints;
 const cashbackPerRedeem = merchant.offer_budget.max_cashback_eur;
 const fallbackSurfaced = Math.round(merchant.demand_gap.gap_density_points * 0.4);
@@ -185,7 +182,7 @@ function App() {
       <section className="summary-grid" aria-label="Campaign summary">
         <Metric label="Surfaced" value={surfaced.toString()} detail="nearby high-intent wallets" />
         <Metric label="Accepted" value={accepted.toString()} detail="saved to wallet" />
-        <Metric label="Redeemed" value={redeemed.toString()} detail="simulated checkout" />
+        <Metric label="Redeemed" value={redeemed.toString()} detail="QR scanned at counter" />
         <Metric
           label="Budget left"
           value={euro(remainingBudget)}
@@ -218,12 +215,7 @@ function App() {
             <Evidence label="Demand gap" value={`${percent(merchant.demand_gap.gap_ratio)} below usual`} />
             <Evidence label="Distance" value={`${merchant.distance_m} m from Mia`} />
           </div>
-          <p className="agent-note">
-            Saturday 13:30 density is {merchant.demand_gap.live_density} vs. a
-            typical {merchant.demand_gap.typical_density}. Latest sample shows
-            {" "}{latestSample?.observed_transactions ?? "9"} transactions,
-            so the rule cleared the approval threshold without merchant review.
-          </p>
+          <MobileMoment />
           <Timeline />
         </article>
 
@@ -396,6 +388,28 @@ function Timeline() {
           </li>
         ))}
       </ol>
+    </div>
+  );
+}
+
+function MobileMoment() {
+  return (
+    <div className="mobile-moment" aria-label="What Mia sees on her phone">
+      <div className="mobile-moment-copy">
+        <span className="label">Mia's mobile moment</span>
+        <p>
+          The same draft becomes a single banner on Mia's phone: hot cocoa,
+          80 m away, expires before the rain stops.
+        </p>
+      </div>
+      <div className="mobile-moment-banner" aria-hidden>
+        <div className="mobile-moment-banner-meta">
+          <span>MomentMarkt</span>
+          <span>now</span>
+        </div>
+        <strong>Cafe Bondi · 80 m</strong>
+        <small>“Es regnet bald. 80 m bis zum heissen Kakao.” · {euro(cashbackPerRedeem)} cashback</small>
+      </div>
     </div>
   );
 }

--- a/apps/merchant/src/styles.css
+++ b/apps/merchant/src/styles.css
@@ -32,6 +32,44 @@ button {
   padding: 28px 0;
 }
 
+.shell > section {
+  animation: section-fade-up 520ms cubic-bezier(0.16, 0.84, 0.3, 1) both;
+}
+
+.shell > section:nth-child(2) {
+  animation-delay: 60ms;
+}
+
+.shell > section:nth-child(3) {
+  animation-delay: 120ms;
+}
+
+.shell > section:nth-child(4) {
+  animation-delay: 180ms;
+}
+
+.shell > section:nth-child(5) {
+  animation-delay: 220ms;
+}
+
+@keyframes section-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shell > section,
+  .metric-value-pulse {
+    animation: none !important;
+  }
+}
+
 .hero-panel,
 .demand-hero,
 .curve-card,
@@ -357,25 +395,25 @@ h3 {
 }
 
 .metric-value-pulse {
-  animation: metric-pulse 700ms ease-out;
+  animation: metric-pulse 900ms cubic-bezier(0.22, 0.71, 0.32, 1);
   transform-origin: left center;
 }
 
 @keyframes metric-pulse {
   0% {
-    color: #18b46c;
-    transform: scale(1.08);
-    text-shadow: 0 0 18px rgba(24, 180, 108, 0.45);
+    color: #1f5040;
+    transform: translateY(0);
+    opacity: 0.55;
   }
-  60% {
-    color: #18b46c;
-    transform: scale(1.02);
-    text-shadow: 0 0 6px rgba(24, 180, 108, 0.2);
+  35% {
+    color: #1f5040;
+    transform: translateY(-2px);
+    opacity: 1;
   }
   100% {
     color: inherit;
-    transform: scale(1);
-    text-shadow: none;
+    transform: translateY(0);
+    opacity: 1;
   }
 }
 
@@ -671,6 +709,63 @@ code {
   height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, #2c7c59, #9ee6b0);
+  transition: width 480ms cubic-bezier(0.22, 0.71, 0.32, 1);
+}
+
+.mobile-moment {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(220px, 1fr);
+  gap: 18px;
+  align-items: center;
+  margin: 0 0 16px;
+  padding: 18px;
+  border-radius: 22px;
+  background: #f4f7f2;
+}
+
+.mobile-moment-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mobile-moment-copy p {
+  margin-bottom: 0;
+  color: #1f5040;
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.mobile-moment-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(28, 28, 30, 0.94);
+  color: #fff8ee;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
+}
+
+.mobile-moment-banner-meta {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(255, 248, 238, 0.6);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mobile-moment-banner strong {
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.mobile-moment-banner small {
+  color: rgba(255, 248, 238, 0.78);
+  font-size: 0.82rem;
+  line-height: 1.45;
 }
 
 @media (max-width: 860px) {
@@ -685,7 +780,8 @@ code {
   .demand-hero,
   .content-grid,
   .offer-box,
-  .evidence-row {
+  .evidence-row,
+  .mobile-moment {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- Adds a compact "Mia's mobile moment" banner inside the draft card to visually connect the merchant draft to the consumer-side surface (issue #106 acceptance: connect the offer to Mia's mobile moment).
- Replaces the dev-flavored "agent note" debug paragraph (now redundant given mmtf's `Timeline` from 6b1e588) and softens "simulated checkout" copy to "QR scanned at counter" so the inbox reads as production-ready in the recording.
- Calm motion: subtle 520ms staggered fade-up on top-level sections, softened metric-pulse (was a green glow + 1.08 scale flash; now a quiet translateY + opacity ease), eased budget-bar width transition, and a `prefers-reduced-motion` guard.

## Out of scope (already covered)
- Demand-gap curve hero — d0972f3.
- Live API status indicator — 0b9895b (#109).
- Signal→draft→auto-approve→surface→redeem timeline — 6b1e588 (kept; my change places the new mobile moment above it inside the draft card).

## Test plan
- [x] `pnpm merchant:typecheck` passes.
- [ ] Sanity-record the merchant inbox once (Devpost cut) — verify the section fade-up doesn't feel jittery on first load and the metric pulse on counter increment is calm.
- [ ] Confirm in 860px breakpoint that the mobile-moment grid stacks cleanly.