### PR TITLE
Docs: convert ASCII art to Mermaid + stale-tech sweep (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pnpm mobile:typecheck
 ```
 
 The Expo app lives in `apps/mobile`. It is the canonical consumer demo surface;
-the older untracked Next.js scaffold under `src/` is obsolete per `spec-v03`.
+the older untracked Next.js scaffold under `src/` is obsolete per `spec-v04`.
 
 ## Run The Merchant Inbox
 
@@ -176,30 +176,19 @@ coordinator Claude Code instance as the dispatcher.
 
 ## Shape
 
-```
-    stage 00: EXPLORE                      stage 01: PLAN
-┌──────────────────────────┐           ┌──────────────────┐
-│ ideator → explorer*      │ ────▶     │ planner          │
-│ (loop until budget or    │           │ writes SPEC.md   │
-│  empty queue)            │           └────────┬─────────┘
-└──────────────────────────┘                    │
-         ▲                                      ▼
-         │                             stage 02: CRITIQUE + REFINE
-         │                             ┌──────────────────────────┐
-         │ EXPLORATION_REQUEST.md ◀────│ critic                   │
-         │                             │ writes CRITIQUE.md       │
-         │                             │ optional: request more   │
-         │                             │ exploration              │
-         │                             └────────┬─────────────────┘
-         │                                      │
-         │                                      ▼
-         │                             planner refines SPEC.md
-         │                                      │
-         │                                      ▼
-         │                             stage 03: JUDGE
-         │                             ┌──────────────────┐
-         └─ or loop again              │ judge → YES/NO   │
-                                       └──────────────────┘
+```mermaid
+flowchart LR
+  EXPLORE["stage 00: EXPLORE<br/>ideator -> explorer*<br/>(loop until budget or empty queue)"]
+  PLAN["stage 01: PLAN<br/>planner<br/>writes SPEC.md"]
+  CRIT["stage 02: CRITIQUE + REFINE<br/>critic writes CRITIQUE.md<br/>(optional: request more exploration)"]
+  REFINE["planner refines SPEC.md"]
+  JUDGE["stage 03: JUDGE<br/>judge -> YES/NO"]
+
+  EXPLORE --> PLAN
+  PLAN --> CRIT
+  CRIT -. "EXPLORATION_REQUEST.md (or loop again)" .-> EXPLORE
+  CRIT --> REFINE
+  REFINE --> JUDGE
 ```
 
 ## Files you fill in before first run

--- a/apps/mobile/e2e/README.md
+++ b/apps/mobile/e2e/README.md
@@ -38,7 +38,7 @@ Open the installed MomentMarkt dev client in the iOS Simulator, then walk:
 3. Surface/offer path expands the sheet and shows the generated widget.
 4. Redeem CTA opens QR/token flow.
 5. Simulated girocard tap shows cashback success.
-6. History/Verlauf shows the receipt-style list.
+6. History tab shows the receipt-style list.
 
 ## Optional Maestro Smoke
 

--- a/assets/architecture-diagrams.md
+++ b/assets/architecture-diagrams.md
@@ -92,7 +92,7 @@ sequenceDiagram
   RN->>SUR: weather flips: rain_incoming<br/>density curve dips
   SUR->>SUR: re-score eligible offers<br/>walk-ring = h3 + 1
   SUR->>OPP: cache lookup (offer_id, weather, intent)
-  OPP-->>SUR: rewritten headline<br/>"Es regnet bald. 80 m..."
+  OPP-->>SUR: rewritten headline<br/>"Rain in 12 min. 80 m to hot cocoa."
   SUR-->>RN: fire in-app card
 
   Mia->>RN: tap card

--- a/assets/architecture-slide.md
+++ b/assets/architecture-slide.md
@@ -13,74 +13,50 @@ Subtitle: *Two agents. Three triggers. One quiet wallet.*
 
 ## Canvas layout (16:9)
 
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│  TOP-LEFT: title block                       TOP-RIGHT: privacy chip         │
-│                                                                              │
-│  CENTER: main flow (left → right)                                            │
-│   [Signals] → [Opportunity Agent] → [Merchant Inbox] → [Surfacing Agent]     │
-│                                                              ↓               │
-│                                                       [RN wallet + redeem]   │
-│                                                                              │
-│  BOTTOM: three production-swap callouts arranged horizontally                │
-│   (a) Surface path     (b) SLM extractor      (c) Payone signal              │
-└──────────────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+  subgraph TOP["TOP"]
+    direction LR
+    TITLE["TOP-LEFT: title block"]
+    CHIP["TOP-RIGHT: privacy chip"]
+  end
+
+  subgraph CENTER["CENTER: main flow"]
+    direction LR
+    S["Signals"] --> OA["Opportunity Agent"] --> MI["Merchant Inbox"] --> SA["Surfacing Agent"] --> WAL["RN wallet + redeem"]
+  end
+
+  subgraph BOTTOM["BOTTOM: three production-swap callouts (horizontal)"]
+    direction LR
+    A["(a) Surface path"]
+    B["(b) SLM extractor"]
+    C["(c) Payone signal"]
+  end
+
+  TOP --> CENTER --> BOTTOM
 ```
 
 ## Main flow (top half of slide)
 
-```text
-   ┌───────────────────────────────────────┐
-   │ SIGNALS (real today)                  │
-   │  • Open-Meteo (Berlin Mitte)          │
-   │  • OSM POIs — 937 Berlin / 2096 ZRH   │
-   │  • VBB GTFS stops (walk-time copy)    │
-   │  • Events stub (event-end trigger)    │
-   │  • data/transactions/                 │
-   │      berlin-density.json (4 merchants)│  ← demand-gap source
-   └──────────────────┬────────────────────┘
-                      │
-                      ▼
-   ┌───────────────────────────────────────┐
-   │ OPPORTUNITY AGENT                     │  «periodic job»
-   │ (LLM-once-per-draft, cheap model)     │  prod: Helm chart /
-   │                                       │  scheduled worker
-   │  Triggers (deterministic Python):     │
-   │    weather  ▸  event-end  ▸  demand   │
-   │  Output per merchant per fire:        │
-   │    { offer, widget_spec(JSON) }       │
-   └──────────────────┬────────────────────┘
-                      │
-                      ▼
-   ┌───────────────────────────────────────┐
-   │ MERCHANT INBOX (web, Vite + React)    │
-   │  • Approve / Edit / Skip              │
-   │  • "Always auto-approve like this"    │
-   │  • Per-merchant demand-curve view     │
-   │    (typical-vs-live, gap highlighted) │
-   └──────────────────┬────────────────────┘
-                      │  approved + auto_approved
-                      ▼
-   ┌───────────────────────────────────────┐    ┌───────────────────────────┐
-   │ SURFACING AGENT                       │ ◀──│ HIGH-INTENT BOOST         │
-   │ (deterministic scoring, NO LLM here)  │    │  • active screen time     │
-   │                                       │    │  • map-app foreground     │
-   │  walk-ring = user.h3 + 1 ring (~1km)  │    │  • coupon-browse recent   │
-   │  silence threshold (default behavior) │    │ → lowers threshold        │
-   │  pick top-1                           │    │ → unlocks aggressive copy │
-   │  on fire: LLM rewrites HEADLINE only  │    └───────────────────────────┘
-   │  cache: (offer_id, weather, intent)   │
-   └──────────────────┬────────────────────┘
-                      │
-                      ▼
-   ┌───────────────────────────────────────┐
-   │ RN WALLET (Expo, iOS Simulator)       │
-   │  in-app card → GenUI widget           │
-   │  6 RN primitives + JSON layout spec   │
-   │  schema-validated, fallback render    │
-   │  → QR token → simulated girocard      │
-   │    cashback, budget decrement         │
-   └───────────────────────────────────────┘
+```mermaid
+flowchart TD
+  SIG["SIGNALS (real today)<br/>- Open-Meteo (Berlin Mitte)<br/>- OSM POIs (937 Berlin / 2096 ZRH)<br/>- VBB GTFS stops (walk-time copy)<br/>- Events stub (event-end trigger)<br/>- data/transactions/berlin-density.json (4 merchants, demand-gap source)"]
+
+  OPP["OPPORTUNITY AGENT (periodic job)<br/>LLM-once-per-draft, cheap model<br/>prod: Helm chart / scheduled worker<br/>Triggers (deterministic Python): weather / event-end / demand<br/>Output per merchant per fire: offer + widget_spec(JSON)"]
+
+  INBOX["MERCHANT INBOX (web, Vite + React)<br/>- Approve / Edit / Skip<br/>- Always auto-approve like this<br/>- Per-merchant demand-curve view (typical-vs-live, gap highlighted)"]
+
+  SURF["SURFACING AGENT (deterministic scoring, NO LLM here)<br/>walk-ring = user.h3 + 1 ring (~1km)<br/>silence threshold (default behavior)<br/>pick top-1<br/>on fire: LLM rewrites HEADLINE only<br/>cache: (offer_id, weather, intent)"]
+
+  HI["HIGH-INTENT BOOST<br/>- active screen time<br/>- map-app foreground<br/>- coupon-browse recent<br/>lowers threshold, unlocks aggressive copy"]
+
+  WALL["RN WALLET (Expo, iOS Simulator)<br/>in-app card -> GenUI widget<br/>6 RN primitives + JSON layout spec<br/>schema-validated, fallback render<br/>QR token -> simulated girocard cashback, budget decrement"]
+
+  SIG --> OPP
+  OPP --> INBOX
+  INBOX -- "approved + auto_approved" --> SURF
+  HI --> SURF
+  SURF --> WALL
 ```
 
 ## Two-agent split annotation (callout block beside the agents)
@@ -123,36 +99,29 @@ the whole pitch beat.
 
 ### (a) Surface path
 
-```
-┌──────────────────────────────┐        ┌────────────────────────────────────┐
-│ DEMO                         │   ─▶   │ PRODUCTION                         │
-│ in-app card slides into the  │        │ Opportunity Agent → push           │
-│ RN wallet on trigger fire    │        │ notification server                │
-│ (no OS permission flow)      │        │ (Expo Push / FCM / APNs) → device  │
-└──────────────────────────────┘        └────────────────────────────────────┘
+```mermaid
+flowchart LR
+  DA["DEMO<br/>in-app card slides into the RN wallet on trigger fire<br/>(no OS permission flow)"]
+  PA["PRODUCTION<br/>Opportunity Agent -> push notification server<br/>(Expo Push / FCM / APNs) -> device"]
+  DA ==> PA
 ```
 
 ### (b) SLM extractor (intent token)
 
-```
-┌──────────────────────────────┐        ┌────────────────────────────────────┐
-│ DEMO                         │   ─▶   │ PRODUCTION                         │
-│ extract_intent_token() stub  │        │ on-device SLM (Phi-3-mini /        │
-│ returns hand-coded enum on   │        │ Gemma-2B) emits intent token;      │
-│ the server                   │        │ only the wrapper leaves the device │
-└──────────────────────────────┘        └────────────────────────────────────┘
+```mermaid
+flowchart LR
+  DB["DEMO<br/>extract_intent_token() stub<br/>returns hand-coded enum on the server"]
+  PB["PRODUCTION<br/>on-device SLM (Phi-3-mini / Gemma-2B) emits intent token;<br/>only the wrapper leaves the device"]
+  DB ==> PB
 ```
 
 ### (c) Payone signal (demand)
 
-```
-┌──────────────────────────────┐        ┌────────────────────────────────────┐
-│ DEMO                         │   ─▶   │ PRODUCTION                         │
-│ data/transactions/           │        │ real cross-Sparkassen Payone       │
-│ berlin-density.json          │        │ aggregation — transaction velocity │
-│ (4 merchants, hand-authored) │        │ already flowing for any merchant   │
-│                              │        │ on a Sparkassen terminal           │
-└──────────────────────────────┘        └────────────────────────────────────┘
+```mermaid
+flowchart LR
+  DC["DEMO<br/>data/transactions/berlin-density.json<br/>(4 merchants, hand-authored)"]
+  PC["PRODUCTION<br/>real cross-Sparkassen Payone aggregation<br/>transaction velocity already flowing for any merchant on a Sparkassen terminal"]
+  DC ==> PC
 ```
 
 ## Aggregate-intelligence callout (bottom-right corner, 10-second pitch beat)

--- a/assets/demo-day/runthrough.md
+++ b/assets/demo-day/runthrough.md
@@ -76,8 +76,8 @@ silent-vs-fire delta).
 
 **VISUAL:** Press the DevPanel **"Run Surfacing Agent"** button (this calls
 `onRunSurfacing()` → sets step to `surfacing`). The `SurfaceNotification`
-slides up over the LockScreen with title "Es regnet bald" and body "80 m bis
-zum heißen Kakao bei Café Bondi. 15% cashback." Emoji ☔.
+slides up over the LockScreen with the headline "Rain in 12 min. 80 m to hot
+cocoa." pointed at Cafe Bondi. Emoji ☔.
 **Say:** "One in-app surface — the only one she'll see this hour. The
 surfacing input crosses the boundary as an intent token plus a coarse H3 cell."
 **Do:** Move the mouse over the DevPanel privacy chip area showing


### PR DESCRIPTION
Closes #112.

## Summary
- Replace ASCII box-drawing diagrams in user-facing docs with Mermaid blocks (renders natively on GitHub)
- Align stray references to current as-built state (English UI per #81, spec-v04)
- Surgical edits only: no prose reflow, no new sections, no heading restructure

## Per-file changes

### `README.md`
- Convert planning-workflow "Shape" diagram (stage 00 -> stage 03) from ASCII boxes/arrows to a `flowchart LR` Mermaid block.
- Stale-tech: `spec-v03` -> `spec-v04` in the "older Next.js scaffold is obsolete" line.

### `assets/architecture-slide.md`
- Convert the 16:9 canvas-layout sketch to a `flowchart TB` with three subgraphs (TOP / CENTER / BOTTOM) showing the main flow + production-swap callouts.
- Convert the main-flow column (Signals -> Opportunity -> Inbox -> Surfacing + High-intent -> RN Wallet) to a `flowchart TD` Mermaid block. Same node labels, same arrows.
- Convert each of the three "production swap" callouts (Surface path / SLM extractor / Payone signal) from side-by-side ASCII boxes to one-line `flowchart LR` Mermaid blocks (`DEMO ==> PRODUCTION`).

### `assets/architecture-diagrams.md`
- Mia sequence diagram: replace lingering German headline `"Es regnet bald. 80 m..."` (returned from the headline-rewrite cache) with the actual English copy used in `cityProfiles.berlin.miaOffer.headline`: `"Rain in 12 min. 80 m to hot cocoa."` (post-#81).
- No structural Mermaid edits; the file already used Mermaid throughout.

### `assets/demo-day/runthrough.md`
- Beat 3 surface notification description: replace German title/body (`"Es regnet bald"` / `"80 m bis zum heißen Kakao bei Café Bondi"`) with the English headline shipped today.
- No ASCII diagrams to convert in this file.

### `apps/backend/README.md`
- No changes. Already Mermaid for the request-flow diagram, already references Pydantic AI + Azure (`gpt-5.5` via `rapidata-hackathon-resource`) + the HF Space.

### `data/README.md`
- No changes. Has only a real Markdown pipe-table (renders fine) and bash code blocks; no box-drawing diagrams.

### `apps/mobile/e2e/README.md`
- Manual smoke step #6: `History/Verlauf` -> `History tab` (UI label is now `History` per #81).
- No ASCII diagrams in this file.

## Mermaid blocks added (count: 7)
1. `README.md` - planning-workflow `flowchart LR` (1 block)
2. `assets/architecture-slide.md` - canvas-layout `flowchart TB` (1 block)
3. `assets/architecture-slide.md` - main-flow `flowchart TD` (1 block)
4. `assets/architecture-slide.md` - production-swap (a) `flowchart LR` (1 block)
5. `assets/architecture-slide.md` - production-swap (b) `flowchart LR` (1 block)
6. `assets/architecture-slide.md` - production-swap (c) `flowchart LR` (1 block)
7. (architecture-diagrams.md already had 5 Mermaid blocks; only string content updated)

## Skip-list respected
Untouched: `planning/`, `context/`, `examples/`, `assets/MD_AUDIT.md` (already deleted on main per `fb73332`), `assets/COVER_RENDER.md`, `assets/LOGO_RENDER.md`, `assets/outreach/*`, `CLAUDE.md`, `work/SPEC.md`, `work/SUBMISSION.md`.

## Validation
- `grep -lE "─|│|┌|└" README.md assets/architecture-slide.md assets/architecture-diagrams.md assets/demo-day/runthrough.md apps/backend/README.md data/README.md apps/mobile/e2e/README.md` -> empty (exit 1) ✓
- `grep -nE "▶|◀|▼|▲|━|═|║"` across the same set -> empty ✓
- Mermaid blocks mentally linted: all node labels quoted with `["..."]` so colons/parens render safely; no mixed-direction-per-diagram; `<br/>` only inside quoted labels.

## Test plan
- [ ] View this PR in the GitHub web UI; all Mermaid blocks render
- [ ] Spot-check the converted README "Shape" diagram still tells the same story (EXPLORE -> PLAN -> CRITIQUE+REFINE -> JUDGE, with the optional EXPLORATION_REQUEST loop back to EXPLORE)
- [ ] Spot-check `assets/architecture-slide.md` main flow renders the 5-box pipeline plus the High-intent boost branch into Surfacing
- [ ] Confirm the headline strings in `architecture-diagrams.md` and `runthrough.md` match the actual `cityProfiles.berlin` headline